### PR TITLE
Fix clean_lines regex removing numbering only with delimiters

### DIFF
--- a/api/extractor/rules.py
+++ b/api/extractor/rules.py
@@ -17,7 +17,8 @@ def clean_lines(t: str) -> List[str]:
     for l in t.splitlines():
         x = l.strip()
         x = re.sub(r'^\s*[\-–—•]*\s*', '', x)      # bullets
-        x = re.sub(r'^\s*\d+\s*[.)-]\s*', '', x)   # 1. 1) 1- etc.
+        # remove prefixos de numeração (1., 1), 1-, 1º, 1.º, 1° etc.)
+        x = re.sub(r'^\s*\d+(?:\s*[\.\)\-º°]+)+\s*', '', x)
         x = x.strip(" -–—;:")
         if x and not x.lower().startswith("nota"):
             lines.append(x)

--- a/api/tests/test_rules.py
+++ b/api/tests/test_rules.py
@@ -1,0 +1,34 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from extractor.rules import clean_lines, split_candidates_by_type
+
+
+def test_clean_lines_removes_ordinals():
+    text = "1.º João Silva\n2° Maria Sousa\n3º- José Lima"
+    assert clean_lines(text) == [
+        "João Silva",
+        "Maria Sousa",
+        "José Lima",
+    ]
+
+
+def test_clean_lines_preserves_leading_digits_without_delimiters():
+    text = "123ABC\n45º DEF"
+    assert clean_lines(text) == [
+        "123ABC",
+        "DEF",
+    ]
+
+
+def test_split_candidates_handles_ordinals():
+    content = """Candidatos efetivos:\n1.º João Silva\n2° Maria Sousa\nCandidatos suplentes:\n1.º Ana Dias"""
+    efetivos, suplentes = split_candidates_by_type(content)
+    assert efetivos == ["João Silva", "Maria Sousa"]
+    assert suplentes == ["Ana Dias"]


### PR DESCRIPTION
## Summary
- require numbering prefixes in clean_lines to include punctuation or ordinal markers so genuine leading digits are preserved
- add regression test ensuring clean_lines keeps identifiers without delimiters while still stripping ordinal formats

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68e58d9dde008321a6d4c8099f67b014