### PR TITLE
Implement UTF-8 sanitization for extraction CSV output

### DIFF
--- a/app/csv_writer.py
+++ b/app/csv_writer.py
@@ -1,34 +1,39 @@
 # -*- coding: utf-8 -*-
-# app/csv_writer.py — Escrita do CSV final no formato CNE
+"""Helper utilities to export the final CNE-compliant CSV file."""
 
 from typing import List, Dict
 import pandas as pd
+
 from app.utils_text import clean_text, sanitize_rows
 
 CNE_COLS = [
-    "DTMNFR","ORGAO","TIPO","SIGLA","SIMBOLO",
-    "NOME_LISTA","NUM_ORDEM","NOME_CANDIDATO",
-    "PARTIDO_PROPONENTE","INDEPENDENTE",
+    "DTMNFR",
+    "ORGAO",
+    "TIPO",
+    "SIGLA",
+    "SIMBOLO",
+    "NOME_LISTA",
+    "NUM_ORDEM",
+    "NOME_CANDIDATO",
+    "PARTIDO_PROPONENTE",
+    "INDEPENDENTE",
 ]
 
+
 def write_cne_csv(rows: List[Dict[str, str]], out_path: str, encoding: str = "utf-8-sig") -> str:
-    """
-    Escreve o CSV final:
-      - Sanitiza todas as strings (corrige mojibake)
-      - Exporta com encoding configurável (default UTF-8-SIG; Excel-friendly)
-        Se o Excel do cliente insistir em falhar a auto-detecção, usar encoding="cp1252".
-    """
-    # 1) Sanitização global defensiva
-    rows = sanitize_rows(rows)
+    """Sanitise the provided ``rows`` and export them to ``out_path``.
 
-    # 2) DataFrame com colunas na ordem exigida
-    df = pd.DataFrame(rows, columns=CNE_COLS)
+    The resulting CSV uses ``;`` as separator (CNE requirement) and writes
+    UTF-8 with BOM by default so Excel autodetects it correctly.
+    """
+    safe_rows = sanitize_rows(rows)
 
-    # 3) “cinto e suspensórios”: limpeza extra em colunas críticas
-    for col in ("NOME_CANDIDATO","NOME_LISTA","PARTIDO_PROPONENTE","SIGLA"):
+    df = pd.DataFrame(safe_rows, columns=CNE_COLS)
+    df = df.fillna("")
+
+    for col in ("NOME_CANDIDATO", "NOME_LISTA", "PARTIDO_PROPONENTE", "SIGLA"):
         if col in df.columns:
             df[col] = df[col].map(clean_text)
 
-    # 4) Export
     df.to_csv(out_path, sep=";", index=False, encoding=encoding)
     return out_path


### PR DESCRIPTION
## Summary
- add mojibake cleaning helpers with ftfy fallback, latin-1 recovery, and NFC normalisation
- sanitise CSV rows before writing and default to UTF-8 with BOM for Excel compatibility
- integrate the sanitised writer into the extract pipeline to clean candidate/list names

## Testing
- python -m compileall app api

------
https://chatgpt.com/codex/tasks/task_b_68e5947c41d08321814275bba49cf512