### PR TITLE
Add Excel-compatible encoding option to extract endpoint

### DIFF
--- a/api/extractor/pipeline.py
+++ b/api/extractor/pipeline.py
@@ -111,7 +111,15 @@ def to_rows_from_block(header_line: str, content: str, orgao_hint: str, dtmnfr: 
             rows.append(build_row(3, n, c)); n += 1
     return rows
 
-def extract_to_csv(in_path: str, out_csv: str, orgao: Optional[str]=None, ord_reset: bool=True, enable_ia: bool=True, models_dir: Optional[str]=None) -> Dict:
+def extract_to_csv(
+    in_path: str,
+    out_csv: str,
+    orgao: Optional[str] = None,
+    ord_reset: bool = True,
+    enable_ia: bool = True,
+    models_dir: Optional[str] = None,
+    encoding: str = "utf-8-sig",
+) -> Dict:
     dtmnfr = infer_dtmnfr_from_path(in_path)
     text = parse_docx(in_path)
     blocks = extract_blocks_with_orgao(text)
@@ -140,7 +148,7 @@ def extract_to_csv(in_path: str, out_csv: str, orgao: Optional[str]=None, ord_re
     if not df.empty:
         df = df.sort_values(by=["ORGAO","SIGLA","TIPO","NOME_LISTA","NUM_ORDEM","NOME_CANDIDATO"]).reset_index(drop=True)
     final_rows = df.to_dict("records")
-    write_cne_csv(final_rows, out_csv)
+    write_cne_csv(final_rows, out_csv, encoding=encoding)
     return {
         "rows": int(df.shape[0]),
         "orgoes": sorted(list(set(df["ORGAO"].unique()))) if "ORGAO" in df else [],

--- a/api/main.py
+++ b/api/main.py
@@ -1,4 +1,4 @@
-from fastapi import FastAPI, UploadFile, File, Form, HTTPException
+from fastapi import FastAPI, UploadFile, File, Form, HTTPException, Query
 from fastapi.responses import JSONResponse, FileResponse
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
@@ -39,7 +39,9 @@ async def extract(
     operator: str = Form(...),
     orgao: Optional[str] = Form(None),
     ord_reset: bool = Form(True),
-    enable_ia: bool = Form(True)
+    enable_ia: bool = Form(True),
+    excel_compat: bool = Query(False),
+    encoding: Optional[str] = Query(None),
 ):
     if operator not in ("A", "B"):
         raise HTTPException(status_code=400, detail="operator deve ser 'A' ou 'B'")
@@ -51,9 +53,15 @@ async def extract(
         f.write(await file.read())
 
     out_csv = os.path.join(APP_DATA, f"extract_{operator}_{ts}.csv")
+    csv_encoding = encoding or ("cp1252" if excel_compat else "utf-8-sig")
     result = extract_to_csv(
-        in_path, out_csv,
-        orgao=orgao, ord_reset=ord_reset, enable_ia=enable_ia, models_dir=MODEL_PATH
+        in_path,
+        out_csv,
+        orgao=orgao,
+        ord_reset=ord_reset,
+        enable_ia=enable_ia,
+        models_dir=MODEL_PATH,
+        encoding=csv_encoding,
     )
 
     return JSONResponse({


### PR DESCRIPTION
## Summary
- add optional query parameters on /extract to request Excel-compatible CSV encoding
- allow custom encoding values to propagate through the extraction pipeline when writing CSV output

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68e5962d1ef083218eae05c7fbcf6061