### PR TITLE
Add regression tests for clean_text mojibake fixes

### DIFF
--- a/app/utils_text.py
+++ b/app/utils_text.py
@@ -85,8 +85,11 @@ def clean_text(value: Optional[str]) -> str:
         except Exception:
             pass
 
+    text = _apply_explicit_fixes(text)
+
     if looks_mojibake(text):
         decoded = _latin1_to_utf8(text)
+        decoded = _apply_explicit_fixes(decoded)
         text = _prefer_candidate(text, decoded)
 
     text = _apply_explicit_fixes(text)

--- a/tests/test_encoding.py
+++ b/tests/test_encoding.py
@@ -1,0 +1,26 @@
+"""Regression tests for mojibake decoding helper functions."""
+
+from pathlib import Path
+import sys
+
+import pytest
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+from app.utils_text import clean_text
+
+
+@pytest.mark.parametrize(
+    "dirty, expected",
+    [
+        ("JoÃ£o", "João"),
+        ("PESSOAS â€“ ANIMAIS", "PESSOAS – ANIMAIS"),
+        ("ClÃ¡udia", "Cláudia"),
+    ],
+)
+def test_clean_text_fixes_common_mojibake(dirty: str, expected: str) -> None:
+    """Ensure ``clean_text`` fixes common mojibake patterns."""
+
+    assert clean_text(dirty) == expected


### PR DESCRIPTION
## Summary
- add regression tests covering common mojibake inputs for clean_text
- adjust clean_text to apply explicit mojibake fixes before latin-1 decoding

## Testing
- pytest -k encoding

------
https://chatgpt.com/codex/tasks/task_b_68e5973473808321a83a0dbbc96b5bdd