### PR TITLE
Add QA export for residual mojibake detection

### DIFF
--- a/app/csv_writer.py
+++ b/app/csv_writer.py
@@ -1,10 +1,11 @@
 # -*- coding: utf-8 -*-
 """Helper utilities to export the final CNE-compliant CSV file."""
 
+from pathlib import Path
 from typing import List, Dict
 import pandas as pd
 
-from app.utils_text import clean_text, sanitize_rows
+from app.utils_text import clean_text, sanitize_rows, looks_mojibake
 
 CNE_COLS = [
     "DTMNFR",
@@ -18,6 +19,24 @@ CNE_COLS = [
     "PARTIDO_PROPONENTE",
     "INDEPENDENTE",
 ]
+
+
+def _row_contains_mojibake(row: pd.Series) -> bool:
+    """Return ``True`` when any field in ``row`` still looks mojibake-heavy."""
+
+    for value in row:
+        if isinstance(value, str) and looks_mojibake(value):
+            return True
+    return False
+
+
+def _export_qa_csv(df: pd.DataFrame, out_path: str) -> str:
+    """Persist a QA CSV listing rows that still contain mojibake tokens."""
+
+    qa_rows = df[df.apply(_row_contains_mojibake, axis=1)]
+    qa_path = Path(out_path).with_name(f"{Path(out_path).stem}_qa.csv")
+    qa_rows.to_csv(qa_path, sep=";", index=False, encoding="utf-8")
+    return str(qa_path)
 
 
 def write_cne_csv(rows: List[Dict[str, str]], out_path: str, encoding: str = "utf-8-sig") -> str:
@@ -36,4 +55,5 @@ def write_cne_csv(rows: List[Dict[str, str]], out_path: str, encoding: str = "ut
             df[col] = df[col].map(clean_text)
 
     df.to_csv(out_path, sep=";", index=False, encoding=encoding)
+    _export_qa_csv(df, out_path)
     return out_path

--- a/tests/test_csv_writer.py
+++ b/tests/test_csv_writer.py
@@ -1,0 +1,52 @@
+"""Tests for :mod:`app.csv_writer`."""
+
+from pathlib import Path
+import sys
+
+import pandas as pd
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+from app.csv_writer import write_cne_csv
+
+
+def _base_row() -> dict:
+    return {
+        "DTMNFR": "2024-01-01",
+        "ORGAO": "CM",
+        "TIPO": "2",
+        "SIGLA": "ABC",
+        "SIMBOLO": "",
+        "NOME_LISTA": "Lista Boa",
+        "NUM_ORDEM": "1",
+        "NOME_CANDIDATO": "João",
+        "PARTIDO_PROPONENTE": "ABC",
+        "INDEPENDENTE": "0",
+    }
+
+
+def test_write_cne_csv_creates_empty_qa_when_clean(tmp_path: Path) -> None:
+    out_path = tmp_path / "clean.csv"
+    write_cne_csv([_base_row()], str(out_path))
+
+    qa_path = out_path.with_name(f"{out_path.stem}_qa.csv")
+    assert qa_path.exists()
+
+    qa_df = pd.read_csv(qa_path, sep=";")
+    assert qa_df.empty
+
+
+def test_write_cne_csv_lists_rows_with_residual_mojibake(tmp_path: Path) -> None:
+    bad_row = _base_row()
+    bad_row["NOME_LISTA"] = "Ã"
+
+    out_path = tmp_path / "bad.csv"
+    write_cne_csv([bad_row], str(out_path))
+
+    qa_path = out_path.with_name(f"{out_path.stem}_qa.csv")
+    qa_df = pd.read_csv(qa_path, sep=";")
+
+    assert len(qa_df) == 1
+    assert qa_df.iloc[0]["NOME_LISTA"] == "Ã"


### PR DESCRIPTION
## Summary
- generate a supplemental *_qa.csv file that lists rows with residual mojibake glyphs after exporting the main CSV
- add regression tests covering clean and mojibake-containing datasets for the QA export

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68e597e8b3b883218c12423316e7d125