### PR TITLE
Add scaffolding for on-premise NLP training

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,8 +1,15 @@
 FROM python:3.11-slim
 WORKDIR /app
-RUN apt-get update && apt-get install -y --no-install-recommends build-essential libxml2 libxslt1.1 && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    libxml2 \
+    libxslt1.1 \
+    libffi-dev \
+    python3-dev \
+ && rm -rf /var/lib/apt/lists/*
 COPY requirements.txt /app/requirements.txt
 RUN pip install --no-cache-dir -r requirements.txt
+RUN python -m spacy download pt_core_news_md
 COPY . /app
 EXPOSE 8000
 CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -5,3 +5,7 @@ pandas==2.2.2
 python-docx==1.1.2
 rapidfuzz==3.9.7
 pydantic==2.8.2
+spacy
+ftfy
+regex
+pyyaml

--- a/app/learn/.gitkeep
+++ b/app/learn/.gitkeep
@@ -1,0 +1,1 @@
+# Placeholder for learning workflows

--- a/data/training/.gitkeep
+++ b/data/training/.gitkeep
@@ -1,0 +1,1 @@
+# Placeholder for training datasets

--- a/models/.gitkeep
+++ b/models/.gitkeep
@@ -1,0 +1,1 @@
+# Placeholder for trained models


### PR DESCRIPTION
## Summary
- add spaCy, ftfy, regex, and PyYAML to the API dependencies for local NLP work
- install required build tooling in the API image and download the Portuguese spaCy model
- create placeholder folders for future learning data and trained models

## Testing
- `docker compose -f docker-compose.min.yml up --build -d` *(fails: docker not available in environment)*

------
https://chatgpt.com/codex/tasks/task_b_68e61447745c83218a6ff96a2f63dad0