### PR TITLE
Fix API Docker build to include shared modules

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,5 +1,7 @@
 FROM python:3.11-slim
+
 WORKDIR /app
+
 RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential \
     libxml2 \
@@ -7,9 +9,14 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libffi-dev \
     python3-dev \
  && rm -rf /var/lib/apt/lists/*
-COPY requirements.txt /app/requirements.txt
-RUN pip install --no-cache-dir -r requirements.txt
+
+COPY api/requirements.txt /tmp/requirements.txt
+RUN pip install --no-cache-dir -r /tmp/requirements.txt
 RUN python -m spacy download pt_core_news_md
-COPY . /app
+
+COPY app /app/app
+COPY api /app
+
 EXPOSE 8000
+
 CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/api/main.py
+++ b/api/main.py
@@ -10,7 +10,7 @@ from app.learn.infer import predict_rows
 from app.csv_writer import write_cne_csv
 from app.utils_text import sanitize_rows
 from app.qa import collect_suspect_rows, write_qa_csv
-from api.extractor.pipeline import infer_dtmnfr_from_path
+from extractor.pipeline import infer_dtmnfr_from_path
 from utils.diff import diff_csvs, validate_csv_schema
 
 APP_DATA = os.environ.get("APP_DATA", "/app/data")

--- a/docker-compose.min.yml
+++ b/docker-compose.min.yml
@@ -1,6 +1,8 @@
 services:
   api:
-    build: ./api
+    build:
+      context: .
+      dockerfile: api/Dockerfile
     image: cne/api:fixed-v2
     container_name: cne_api_fixed_v2
     ports:


### PR DESCRIPTION
## Summary
- copy the shared `app` package into the API image during the Docker build
- adjust docker-compose to build the API image from the repository root so the shared code is available
- correct the extractor import path inside the FastAPI application entrypoint

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68e639b9f1f8832184dd529a91786996