### PR TITLE
Adjust API Dockerfile for correct app startup

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -2,6 +2,9 @@ FROM python:3.11-slim
 
 WORKDIR /app
 
+ENV PYTHONUNBUFFERED=1
+ENV PYTHONPATH=/app
+
 RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential \
     libxml2 \
@@ -17,6 +20,8 @@ RUN python -m spacy download pt_core_news_md
 COPY app /app/app
 COPY api /app
 
+RUN mkdir -p /app/out /app/data /app/models
+
 EXPOSE 8000
 
-CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]


### PR DESCRIPTION
## Summary
- ensure the API container sets PYTHONPATH to /app and runs in unbuffered mode
- create data, out, and models directories during the image build
- update uvicorn to load app.main:app when starting the container

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68e63b3ffbbc83218c9b5530c740f503