### PR TITLE
Ensure CNE CSV encoding and schema

### DIFF
--- a/api/app/csv_writer.py
+++ b/api/app/csv_writer.py
@@ -19,6 +19,7 @@ CNE_COLS = [
     "PARTIDO_PROPONENTE",
     "INDEPENDENTE",
 ]
+
 def write_cne_csv(
     rows: List[Dict[str, str]],
     out_path: str,


### PR DESCRIPTION
## Summary
- ensure the CSV writer exposes the CNE column order constant directly after its declaration
- add regression tests validating the UTF-8 BOM encoding, semicolon separator, and header order for the exported CSV
- adjust CSV writer tests to add the repository and API package paths to `sys.path`

## Testing
- pytest tests/test_csv_writer.py

------
https://chatgpt.com/codex/tasks/task_b_68e63c652a648321b5b8ed9e11aa72a5