### PR TITLE
Fix app package path for extractor import

### DIFF
--- a/api/app/__init__.py
+++ b/api/app/__init__.py
@@ -1,0 +1,15 @@
+"""Application package bootstrap helpers."""
+
+from pathlib import Path
+import sys
+
+_APP_DIR = Path(__file__).resolve().parent
+_API_DIR = _APP_DIR.parent
+_REPO_ROOT = _API_DIR.parent
+
+for path in (_REPO_ROOT, _API_DIR):
+    path_str = str(path)
+    if path_str not in sys.path:
+        sys.path.append(path_str)
+
+__all__ = []


### PR DESCRIPTION
## Summary
- ensure the app package initialisation adds the repository root and API directory to sys.path so the extractor pipeline can be imported without errors

## Testing
- python - <<'PY'
from app.main import infer_dtmnfr_from_path
print(infer_dtmnfr_from_path('foo_2023_bar.docx'))
PY

------
https://chatgpt.com/codex/tasks/task_b_68e63d282a648321aac56993acaea168