### PR TITLE
Add merge output directory handling and endpoint tests

### DIFF
--- a/api/app/main.py
+++ b/api/app/main.py
@@ -16,6 +16,7 @@ from utils.diff import diff_csvs, validate_csv_schema
 
 APP_DATA = os.environ.get("APP_DATA", "/app/data")
 MODEL_PATH = os.environ.get("MODEL_PATH", "/app/models")
+MERGE_OUT_DIR = Path(os.environ.get("MERGE_OUT_DIR", "/app/out"))
 STRICT_TEMPLATES = os.environ.get("STRICT_TEMPLATES", "").lower() in {"1", "true", "yes", "on"}
 
 app = FastAPI(title="CNE On-Prem Extractor (Fixed V2)", version="0.4.0")
@@ -154,7 +155,7 @@ async def extract(
 def merge(req: MergeRequest):
     if not os.path.exists(req.csv_a) or not os.path.exists(req.csv_b):
         raise HTTPException(status_code=400, detail="CSV paths inválidos")
-    base_out_dir = Path(APP_DATA)
+    base_out_dir = MERGE_OUT_DIR
     base_out_dir.mkdir(parents=True, exist_ok=True)
     out_path = Path(req.out_path) if req.out_path else base_out_dir / "final_merged.csv"
     out_path.parent.mkdir(parents=True, exist_ok=True)

--- a/api/tests/test_merge_validate.py
+++ b/api/tests/test_merge_validate.py
@@ -1,0 +1,78 @@
+from pathlib import Path
+import sys
+
+from fastapi.testclient import TestClient
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from app.main import app
+
+
+HEADER = "DTMNFR;ORGAO;TIPO;SIGLA;SIMBOLO;NOME_LISTA;NUM_ORDEM;NOME_CANDIDATO;PARTIDO_PROPONENTE;INDEPENDENTE"
+
+
+def write_csv(path: Path, rows):
+    lines = [HEADER]
+    lines.extend(rows)
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+client = TestClient(app)
+
+
+def test_validate_endpoint_returns_ok_for_valid_csv(tmp_path):
+    csv_path = tmp_path / "valid.csv"
+    write_csv(
+        csv_path,
+        [
+            "2024;CM;2;AAA;SYM;Lista A;1;João Silva;Partido A;N",
+        ],
+    )
+
+    response = client.post("/validate", json={"csv_path": str(csv_path)})
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["ok"] is True
+    assert payload["rows"] == 1
+    assert payload["issues"] == []
+
+
+def test_merge_endpoint_creates_file_and_reports_rows(tmp_path):
+    csv_a = tmp_path / "csv_a.csv"
+    csv_b = tmp_path / "csv_b.csv"
+    out_path = tmp_path / "merged" / "final.csv"
+
+    write_csv(
+        csv_a,
+        [
+            "2024;CM;2;AAA;SYM;Lista A;1;João Silva;Partido A;N",
+        ],
+    )
+    write_csv(
+        csv_b,
+        [
+            "2024;CM;2;AAA;SYM;Lista A;1;João Silva;Partido A;N",
+            "2024;AM;3;BBB;SYM;Lista B;2;Maria Souza;Partido B;S",
+        ],
+    )
+
+    response = client.post(
+        "/merge",
+        json={
+            "csv_a": str(csv_a),
+            "csv_b": str(csv_b),
+            "out_path": str(out_path),
+        },
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["final_csv"] == str(out_path)
+    assert payload["rows"] == 2
+    assert Path(payload["final_csv"]).exists()
+
+    merged_content = out_path.read_text(encoding="utf-8").strip().splitlines()
+    assert merged_content[0] == HEADER
+    assert len(merged_content) == 3


### PR DESCRIPTION
## Summary
- ensure the merge endpoint writes merged CSVs to a dedicated /app/out directory when no path is provided
- cover the /validate and /merge endpoints with FastAPI tests to confirm schema validation and merged output details

## Testing
- cd api && pytest

------
https://chatgpt.com/codex/tasks/task_b_68e63df07c10832187132689a7def066