### PR TITLE
Write QA CSVs to /app/out

### DIFF
--- a/api/app/main.py
+++ b/api/app/main.py
@@ -130,8 +130,8 @@ async def extract(
     write_cne_csv(safe_rows, out_csv, encoding=csv_encoding)
 
     qa_path = None
-    if qa:
-        qa_path, _ = write_qa_csv(
+    if qa or suspect_rows:
+        qa_path, suspect_rows = write_qa_csv(
             safe_rows,
             out_csv,
             metadata=pipeline_meta,

--- a/api/app/qa.py
+++ b/api/app/qa.py
@@ -79,6 +79,8 @@ def _gather_fieldnames(rows: Iterable[Dict[str, Any]]) -> List[str]:
             seen.add(extra)
     return ordered
 
+QA_OUTPUT_DIR = Path("/app/out")
+
 
 def write_qa_csv(
     rows: Sequence[Dict[str, Any]],
@@ -88,10 +90,10 @@ def write_qa_csv(
     suspects: Optional[Sequence[Dict[str, Any]]] = None,
     encoding: str = "utf-8-sig",
 ) -> Tuple[str, List[Dict[str, Any]]]:
-    """Persist a QA CSV next to ``output_csv_path`` and return its location."""
+    """Persist a QA CSV in ``/app/out`` and return its location."""
 
-    qa_path = Path(output_csv_path)
-    qa_path = qa_path.with_name(f"{qa_path.stem}_qa.csv")
+    qa_name = f"{Path(output_csv_path).stem}_qa.csv"
+    qa_path = QA_OUTPUT_DIR / qa_name
     qa_path.parent.mkdir(parents=True, exist_ok=True)
 
     suspect_rows = list(suspects) if suspects is not None else collect_suspect_rows(

--- a/tests/test_csv_writer.py
+++ b/tests/test_csv_writer.py
@@ -43,6 +43,22 @@ def test_write_qa_csv_creates_empty_file_when_clean(tmp_path: Path) -> None:
     qa_df = pd.read_csv(qa_path, sep=";")
     assert qa_df.empty
 
+    Path(qa_path).unlink()
+
+
+def test_write_qa_csv_default_location() -> None:
+    rows = [_base_row()]
+    out_path = Path("/tmp/out.csv")
+
+    qa_path, _ = write_qa_csv(rows, str(out_path))
+    qa_path_obj = Path(qa_path)
+
+    assert qa_path_obj.parent == Path("/app/out")
+    assert qa_path_obj.name == f"{out_path.stem}_qa.csv"
+    assert qa_path_obj.exists()
+
+    qa_path_obj.unlink()
+
 
 def test_collect_suspect_rows_flags_mojibake(tmp_path: Path) -> None:
     bad_row = _base_row()
@@ -60,6 +76,8 @@ def test_collect_suspect_rows_flags_mojibake(tmp_path: Path) -> None:
 
     assert len(qa_df) == 1
     assert qa_df.iloc[0]["NOME_LISTA"] == "Ã"
+
+    Path(qa_path).unlink()
 
 
 def test_write_cne_csv_uses_utf8_sig_and_semicolon(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- generate QA CSVs to /app/out through the QA helper
- emit QA files automatically when QA is requested or suspect rows are present so the API response reports their location
- update QA writer tests to cover the new default output directory

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68e63ef7a8388321a7ab41a162676b8c